### PR TITLE
Tweaks

### DIFF
--- a/agent/candidate_test.go
+++ b/agent/candidate_test.go
@@ -34,14 +34,14 @@ func TestGetCandidateNodes(t *testing.T) {
 			desc: "Two candidates",
 			expectedCandidates: []nodeCandidate{
 				{
-					PublicKey: "bob",
-					Addresses: []string{},
-					Score:     7.167,
-				},
-				{
 					PublicKey: "dave",
 					Addresses: []string{},
-					Score:     7,
+					Score:     6.6,
+				},
+				{
+					PublicKey: "bob",
+					Addresses: []string{},
+					Score:     6.367,
 				},
 			},
 			localNode: local.Node{
@@ -275,11 +275,27 @@ func TestDiscardNode(t *testing.T) {
 		{
 			desc: "Shared peers",
 			localNode: local.Node{
-				ChannelPeers: map[string]struct{}{"alice": {}},
+				ChannelPeers: map[string]struct{}{
+					"alice":  {},
+					"carol":  {},
+					"dave":   {},
+					"erin":   {},
+					"frank":  {},
+					"george": {},
+					"harold": {},
+					"ian":    {},
+					"jane":   {},
+					"kate":   {},
+				},
 			},
 			peerNode: graph.Node{
 				PublicKey: "bob",
-				Channels:  []graph.Channel{{PeerPublicKey: "alice"}},
+				Channels: []graph.Channel{
+					{PeerPublicKey: "alice"},
+					{PeerPublicKey: "carol"},
+					{PeerPublicKey: "dave"},
+					{PeerPublicKey: "erin"},
+				},
 			},
 			discard: true,
 		},

--- a/agent/local/channel.go
+++ b/agent/local/channel.go
@@ -48,7 +48,7 @@ func getChannels(
 	peers []*lnrpc.Peer,
 ) (Channels, error) {
 	oneMonthAgo := uint64(time.Now().Add(-oneMonth).Unix())
-	forwards, err := ListForwards(ctx, lnd, oneMonthAgo, 0)
+	forwards, err := ListForwards(ctx, lnd, 0, oneMonthAgo, 0)
 	if err != nil {
 		return Channels{}, err
 	}
@@ -90,6 +90,7 @@ func getChannels(
 func ListForwards(
 	ctx context.Context,
 	lnd lightning.Client,
+	channelID uint64,
 	startTime uint64,
 	offset uint32,
 ) ([]*lnrpc.ForwardingEvent, error) {
@@ -97,7 +98,7 @@ func ListForwards(
 	now := uint64(time.Now().Unix())
 
 	for {
-		forwards, err := lnd.ListForwards(ctx, startTime, now, offset)
+		forwards, err := lnd.ListForwards(ctx, channelID, startTime, now, offset)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/local/node_test.go
+++ b/agent/local/node_test.go
@@ -61,12 +61,13 @@ func TestGetNode(t *testing.T) {
 			walletResp := &lnrpc.WalletBalanceResponse{
 				ConfirmedBalance: tt.balance,
 			}
+			channelID := uint64(191315023298560)
 			channelsResp := []*lnrpc.Channel{
 				{
 					Active:       true,
 					RemotePubkey: "test_peer",
 					ChannelPoint: "e5b8ccc43b4eea6e2664a843e27d82c6d71d2885e7aef73777dd35c737c1d7bc:1",
-					ChanId:       191315023298560,
+					ChanId:       channelID,
 					Capacity:     2_000_000,
 				},
 			}
@@ -83,7 +84,7 @@ func TestGetNode(t *testing.T) {
 			forwardsResp := &lnrpc.ForwardingHistoryResponse{
 				ForwardingEvents: []*lnrpc.ForwardingEvent{
 					{
-						ChanIdIn:  191315023298560,
+						ChanIdIn:  channelID,
 						AmtInMsat: 500,
 						FeeMsat:   10,
 					},
@@ -98,7 +99,7 @@ func TestGetNode(t *testing.T) {
 			lndMock.On("ListPeers", ctx).Return(peersResp, nil)
 			lndMock.On("ClosedChannels", ctx).Return(closedChannelsResp, nil)
 			lndMock.On("EstimateTxFee", ctx, config.TargetConf).Return(feeResp, nil)
-			lndMock.On("ListForwards", ctx, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
+			lndMock.On("ListForwards", ctx, uint64(0), mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
 
 			expectedNode := local.Node{
 				PublicKey: infoResp.IdentityPubkey,

--- a/config/config.go
+++ b/config/config.go
@@ -30,9 +30,9 @@ var (
 		},
 		Channels: ChannelsWeights{
 			BaseFee:        1,
-			FeeRate:        0.7,
-			InboundBaseFee: 0.8,
-			InboundFeeRate: 0.7,
+			FeeRate:        0.4,
+			InboundBaseFee: 0.4,
+			InboundFeeRate: 0.4,
 			MinHTLC:        1,
 			MaxHTLC:        0.6,
 			BlockHeight:    0.8,
@@ -276,7 +276,7 @@ func (c *Config) Validate() error {
 
 func (c *Config) setDefaults() {
 	if c.Agent.AllocationPercent == 0 {
-		c.Agent.AllocationPercent = 60
+		c.Agent.AllocationPercent = 80
 	}
 
 	if c.Agent.MinChannels == 0 {
@@ -308,7 +308,7 @@ func (c *Config) setDefaults() {
 	}
 
 	if c.Agent.ChannelManager.FeeRatePPM == 0 {
-		c.Agent.ChannelManager.FeeRatePPM = 100
+		c.Agent.ChannelManager.FeeRatePPM = 2_000
 	}
 
 	if c.Agent.HeuristicWeights.Open == (OpenWeights{}) {
@@ -346,16 +346,16 @@ func IterWeights[T Weights](weights T, f func(weight float64) error) error {
 	var err error
 	w := reflect.ValueOf(weights)
 	for i := range w.NumField() {
-		weight := w.Field(i).Interface()
-		switch weight.(type) {
+		field := w.Field(i).Interface()
+		switch weight := field.(type) {
 		case float64:
-			err = f(weight.(float64))
+			err = f(weight)
 		case CentralityWeights:
-			err = IterWeights(weight.(CentralityWeights), func(v float64) error {
+			err = IterWeights(weight, func(v float64) error {
 				return f(v)
 			})
 		case ChannelsWeights:
-			err = IterWeights(weight.(ChannelsWeights), func(v float64) error {
+			err = IterWeights(weight, func(v float64) error {
 				return f(v)
 			})
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -148,14 +148,14 @@ func TestSetDefaults(t *testing.T) {
 	config := &Config{}
 	config.setDefaults()
 
-	assert.Equal(t, uint64(60), config.Agent.AllocationPercent)
+	assert.Equal(t, uint64(80), config.Agent.AllocationPercent)
 	assert.Equal(t, uint64(2), config.Agent.MinChannels)
 	assert.Equal(t, uint64(200), config.Agent.MaxChannels)
 	assert.Equal(t, int32(6), config.Agent.TargetConf)
 	assert.Equal(t, uint64(1_000_000), config.Agent.MinChannelSize)
 	assert.Equal(t, uint64(10_000_000), config.Agent.MaxChannelSize)
 	assert.Equal(t, int32(2), config.Agent.ChannelManager.MinConf, 2)
-	assert.Equal(t, uint64(100), config.Agent.ChannelManager.FeeRatePPM)
+	assert.Equal(t, uint64(2_000), config.Agent.ChannelManager.FeeRatePPM)
 	assert.Equal(t, uint64(50), config.Agent.ChannelManager.MaxSatvB)
 	assert.Equal(t, DefaultOpenWeights, config.Agent.HeuristicWeights.Open)
 	assert.Equal(t, DefaultCloseWeights, config.Agent.HeuristicWeights.Close)

--- a/docker/mainnet/hydrus.yml
+++ b/docker/mainnet/hydrus.yml
@@ -28,21 +28,21 @@ agent:
   heuristic_weights:
     open:
       capacity: 1
-      features: 0.6
+      features: 0
       hybrid: 1
       centrality:
-        degree: 0.4
+        degree: 0
         closeness: 1
         betweenness: 1
-        eigenvector: 1
+        eigenvector: 0
       channels:
-        base_fee: 0.8
-        fee_rate: 0.8
-        inbound_base_fee: 0.8
-        inbound_fee_rate: 0.8
+        base_fee: 0
+        fee_rate: 0
+        inbound_base_fee: 0
+        inbound_fee_rate: 0
         min_htlc: 1
         max_htlc: 0.5
-        block_height: 1
+        block_height: 0.6
     close:
       capacity: 0.9
       active: 1

--- a/graph/heuristic_test.go
+++ b/graph/heuristic_test.go
@@ -61,7 +61,7 @@ func TestHeuristicsGetScore(t *testing.T) {
 				},
 				NumFeatures: 12,
 			},
-			expectedScore: 8.2,
+			expectedScore: 7.2,
 		},
 		{
 			desc:       "Default values 2",
@@ -87,7 +87,7 @@ func TestHeuristicsGetScore(t *testing.T) {
 				},
 				NumFeatures: 12,
 			},
-			expectedScore: 6.8,
+			expectedScore: 6.4,
 		},
 		{
 			desc: "Full weights",

--- a/lightning/mock.go
+++ b/lightning/mock.go
@@ -93,11 +93,12 @@ func (c *ClientMock) ListChannels(ctx context.Context) ([]*lnrpc.Channel, error)
 // ListForwards mock.
 func (c *ClientMock) ListForwards(
 	ctx context.Context,
+	channelID uint64,
 	startTime,
 	endTime uint64,
 	indexOffset uint32,
 ) (*lnrpc.ForwardingHistoryResponse, error) {
-	args := c.Called(ctx, startTime, endTime, indexOffset)
+	args := c.Called(ctx, channelID, startTime, endTime, indexOffset)
 	return mockReturn[*lnrpc.ForwardingHistoryResponse](args)
 }
 


### PR DESCRIPTION
## Description

- Adjusts default values to provide a better baseline
- List forwards channel by channel instead of obtaining all of them in a single call (support added in LND v0.20.0)
- Prevents the channel policy updates from being too small and triggering `FEE_INSUFICIENT` errors that would cause the node to be penalized when looking for paths.