### PR TITLE
Use SCID in forwarding events operations

### DIFF
--- a/agent/local/channel.go
+++ b/agent/local/channel.go
@@ -9,11 +9,11 @@ import (
 	"github.com/aftermath2/hydrus/lightning"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
+	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 const (
 	oneDay   = time.Hour * 24
-	oneWeek  = oneDay * 7
 	oneMonth = oneDay * 30
 )
 
@@ -48,10 +48,6 @@ func getChannels(
 	peers []*lnrpc.Peer,
 ) (Channels, error) {
 	oneMonthAgo := uint64(time.Now().Add(-oneMonth).Unix())
-	forwards, err := ListForwards(ctx, lnd, 0, oneMonthAgo, 0)
-	if err != nil {
-		return Channels{}, err
-	}
 
 	heuristics := NewHeuristics(closeWeights)
 	chans := make([]Channel, 0, len(channels))
@@ -59,6 +55,11 @@ func getChannels(
 		if channel.Private {
 			// Do not close private channels
 			continue
+		}
+
+		forwards, err := ListForwards(ctx, lnd, channel.ChanId, oneMonthAgo, 0)
+		if err != nil {
+			return Channels{}, err
 		}
 
 		numForwards, forwardsAmount, fees := getForwardsInfo(channel, forwards)
@@ -97,8 +98,10 @@ func ListForwards(
 	events := make([]*lnrpc.ForwardingEvent, 0)
 	now := uint64(time.Now().Unix())
 
+	scid := lnwire.NewShortChanIDFromInt(channelID).ToUint64()
+
 	for {
-		forwards, err := lnd.ListForwards(ctx, channelID, startTime, now, offset)
+		forwards, err := lnd.ListForwards(ctx, scid, startTime, now, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +122,9 @@ func ListForwards(
 func getForwardsInfo(channel *lnrpc.Channel, forwards []*lnrpc.ForwardingEvent) (uint64, uint64, uint64) {
 	var numForwards, forwardsAmount, fees uint64
 	for _, forward := range forwards {
-		if forward.ChanIdIn == channel.ChanId {
+		scid := lnwire.NewShortChanIDFromInt(channel.ChanId).ToUint64()
+
+		if forward.ChanIdIn == scid {
 			numForwards++
 			forwardsAmount += forward.AmtInMsat
 			// Even though we collect fees in the other part of the circuit, we are counting fees for this
@@ -127,7 +132,7 @@ func getForwardsInfo(channel *lnrpc.Channel, forwards []*lnrpc.ForwardingEvent) 
 			fees += forward.FeeMsat
 		}
 
-		if forward.ChanIdOut == channel.ChanId {
+		if forward.ChanIdOut == scid {
 			numForwards++
 			forwardsAmount += forward.AmtOutMsat
 			fees += forward.FeeMsat

--- a/agent/local/channel_test.go
+++ b/agent/local/channel_test.go
@@ -65,7 +65,9 @@ func TestGetChannels(t *testing.T) {
 		LastOffsetIndex: 3,
 	}
 
-	lndMock.On("ListForwards", ctx, uint64(0), mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
+	lndMock.On("ListForwards", ctx, ch1.ChanId, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil).Once()
+	lndMock.On("ListForwards", ctx, ch2.ChanId, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil).Once()
+	lndMock.On("ListForwards", ctx, ch3.ChanId, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil).Once()
 
 	weights := config.CloseWeights{
 		Capacity:       0.2,

--- a/agent/local/node_test.go
+++ b/agent/local/node_test.go
@@ -99,7 +99,7 @@ func TestGetNode(t *testing.T) {
 			lndMock.On("ListPeers", ctx).Return(peersResp, nil)
 			lndMock.On("ClosedChannels", ctx).Return(closedChannelsResp, nil)
 			lndMock.On("EstimateTxFee", ctx, config.TargetConf).Return(feeResp, nil)
-			lndMock.On("ListForwards", ctx, uint64(0), mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
+			lndMock.On("ListForwards", ctx, channelID, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
 
 			expectedNode := local.Node{
 				PublicKey: infoResp.IdentityPubkey,

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -56,7 +56,7 @@ type Client interface {
 	GetChanInfo(ctx context.Context, channelID uint64) (*lnrpc.ChannelEdge, error)
 	GetInfo(ctx context.Context) (*lnrpc.GetInfoResponse, error)
 	ListChannels(ctx context.Context) ([]*lnrpc.Channel, error)
-	ListForwards(ctx context.Context, channelID uint64, startTime, endTime uint64, indexOffset uint32) (*lnrpc.ForwardingHistoryResponse, error)
+	ListForwards(ctx context.Context, scid uint64, startTime, endTime uint64, indexOffset uint32) (*lnrpc.ForwardingHistoryResponse, error)
 	ListPeers(ctx context.Context) ([]*lnrpc.Peer, error)
 	QueryRoute(ctx context.Context, publicKey string) (*lnrpc.QueryRoutesResponse, error)
 	UpdateChannelPolicy(ctx context.Context, channelPoint string, baseFeeMsat, feeRatePPM, maxHTLCMsat, timeLockDelta uint64) error
@@ -303,13 +303,13 @@ func (c *client) ListChannels(ctx context.Context) ([]*lnrpc.Channel, error) {
 // ListForwards returns list of successful HTLC forwarding events.
 func (c *client) ListForwards(
 	ctx context.Context,
-	channelID uint64,
+	scid uint64,
 	startTime,
 	endTime uint64,
 	indexOffset uint32,
 ) (*lnrpc.ForwardingHistoryResponse, error) {
-	channelIDs := []uint64{channelID}
-	if channelID == 0 {
+	channelIDs := []uint64{scid}
+	if scid == 0 {
 		channelIDs = nil
 	}
 


### PR DESCRIPTION
## Description

The `lnrpc.ForwardingHistory` RPC method accepts lists of short channel IDs (SCIDs) instead of full channel IDs. This causes a silent error where it always returns an empty list because the filter does not match any channel.