### PR TITLE
List forwards without filters

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -283,17 +283,16 @@ func (a *agent) UpdatePolicies(ctx context.Context, localNode local.Node) error 
 	}
 
 	startTime := uint64(time.Now().Add(-a.config.Intervals.RoutingPolicies).Unix())
+	forwards, err := local.ListForwards(ctx, a.lnd, startTime)
+	if err != nil {
+		return err
+	}
 
 	for _, ch := range localNode.Channels.List {
 		policy, err := getChannelPolicy(ctx, a.lnd, localNode.PublicKey, ch)
 		if err != nil {
 			a.logger.Error(err)
 			continue
-		}
-
-		forwards, err := local.ListForwards(ctx, a.lnd, ch.ID, startTime, 0)
-		if err != nil {
-			return err
 		}
 
 		forwardsAmountIn := uint64(0)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -332,7 +332,7 @@ func TestUpdatePolicies(t *testing.T) {
 	expectedFeeRatePPM := uint64(100)
 	expectedMaxHTLCMsat := uint64(1_970_400_000)
 
-	lndMock.On("ListForwards", ctx, channelID, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
+	lndMock.On("ListForwards", ctx, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
 	lndMock.On("GetChanInfo", ctx, channelID).Return(chanInfoResp, nil)
 	lndMock.On("UpdateChannelPolicy",
 		ctx,
@@ -713,5 +713,5 @@ func getNode(t *testing.T, lndMock *lightning.ClientMock, config config.Agent, s
 	lndMock.On("ListPeers", ctx).Return(peersResp, nil)
 	lndMock.On("ClosedChannels", ctx).Return(closedChannelsResp, nil)
 	lndMock.On("EstimateTxFee", ctx, config.TargetConf).Return(feeResp, nil)
-	lndMock.On("ListForwards", ctx, mock.Anything, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
+	lndMock.On("ListForwards", ctx, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
 }

--- a/agent/local/channel.go
+++ b/agent/local/channel.go
@@ -9,11 +9,11 @@ import (
 	"github.com/aftermath2/hydrus/lightning"
 
 	"github.com/lightningnetwork/lnd/lnrpc"
-	"github.com/lightningnetwork/lnd/lnwire"
 )
 
 const (
 	oneDay   = time.Hour * 24
+	oneWeek  = oneDay * 7
 	oneMonth = oneDay * 30
 )
 
@@ -48,6 +48,10 @@ func getChannels(
 	peers []*lnrpc.Peer,
 ) (Channels, error) {
 	oneMonthAgo := uint64(time.Now().Add(-oneMonth).Unix())
+	forwards, err := ListForwards(ctx, lnd, oneMonthAgo)
+	if err != nil {
+		return Channels{}, err
+	}
 
 	heuristics := NewHeuristics(closeWeights)
 	chans := make([]Channel, 0, len(channels))
@@ -55,11 +59,6 @@ func getChannels(
 		if channel.Private {
 			// Do not close private channels
 			continue
-		}
-
-		forwards, err := ListForwards(ctx, lnd, channel.ChanId, oneMonthAgo, 0)
-		if err != nil {
-			return Channels{}, err
 		}
 
 		numForwards, forwardsAmount, fees := getForwardsInfo(channel, forwards)
@@ -91,17 +90,14 @@ func getChannels(
 func ListForwards(
 	ctx context.Context,
 	lnd lightning.Client,
-	channelID uint64,
 	startTime uint64,
-	offset uint32,
 ) ([]*lnrpc.ForwardingEvent, error) {
 	events := make([]*lnrpc.ForwardingEvent, 0)
 	now := uint64(time.Now().Unix())
-
-	scid := lnwire.NewShortChanIDFromInt(channelID).ToUint64()
+	offset := uint32(0)
 
 	for {
-		forwards, err := lnd.ListForwards(ctx, scid, startTime, now, offset)
+		forwards, err := lnd.ListForwards(ctx, startTime, now, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -122,9 +118,7 @@ func ListForwards(
 func getForwardsInfo(channel *lnrpc.Channel, forwards []*lnrpc.ForwardingEvent) (uint64, uint64, uint64) {
 	var numForwards, forwardsAmount, fees uint64
 	for _, forward := range forwards {
-		scid := lnwire.NewShortChanIDFromInt(channel.ChanId).ToUint64()
-
-		if forward.ChanIdIn == scid {
+		if forward.ChanIdIn == channel.ChanId {
 			numForwards++
 			forwardsAmount += forward.AmtInMsat
 			// Even though we collect fees in the other part of the circuit, we are counting fees for this
@@ -132,7 +126,7 @@ func getForwardsInfo(channel *lnrpc.Channel, forwards []*lnrpc.ForwardingEvent) 
 			fees += forward.FeeMsat
 		}
 
-		if forward.ChanIdOut == scid {
+		if forward.ChanIdOut == channel.ChanId {
 			numForwards++
 			forwardsAmount += forward.AmtOutMsat
 			fees += forward.FeeMsat

--- a/agent/local/channel_test.go
+++ b/agent/local/channel_test.go
@@ -64,10 +64,7 @@ func TestGetChannels(t *testing.T) {
 		},
 		LastOffsetIndex: 3,
 	}
-
-	lndMock.On("ListForwards", ctx, ch1.ChanId, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil).Once()
-	lndMock.On("ListForwards", ctx, ch2.ChanId, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil).Once()
-	lndMock.On("ListForwards", ctx, ch3.ChanId, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil).Once()
+	lndMock.On("ListForwards", ctx, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
 
 	weights := config.CloseWeights{
 		Capacity:       0.2,
@@ -163,7 +160,7 @@ func TestListForwards(t *testing.T) {
 	lndMock := lightning.NewClientMock()
 	startTime := uint64(0)
 	offset := uint32(0)
-	channelID := uint64(1)
+	events := make([]*lnrpc.ForwardingEvent, 0)
 	expectedEvents := []*lnrpc.ForwardingEvent{
 		{Timestamp: 1},
 		{Timestamp: 2},
@@ -173,9 +170,9 @@ func TestListForwards(t *testing.T) {
 		LastOffsetIndex:  uint32(len(expectedEvents)),
 	}
 
-	lndMock.On("ListForwards", ctx, channelID, startTime, mock.Anything, offset).Return(resp, nil)
+	lndMock.On("ListForwards", ctx, startTime, mock.Anything, offset).Return(resp, nil)
 
-	events, err := ListForwards(ctx, lndMock, channelID, startTime, offset)
+	events, err := ListForwards(ctx, lndMock, startTime)
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedEvents, events)
@@ -186,8 +183,8 @@ func TestListForwardsRecursion(t *testing.T) {
 	lndMock := lightning.NewClientMock()
 	startTime := uint64(0)
 	offset := uint32(0)
-	channelID := uint64(1)
 
+	events := make([]*lnrpc.ForwardingEvent, 0, lightning.MaxForwardingEvents)
 	expectedEvents := make([]*lnrpc.ForwardingEvent, lightning.MaxForwardingEvents)
 
 	for i := range lightning.MaxForwardingEvents {
@@ -205,16 +202,10 @@ func TestListForwardsRecursion(t *testing.T) {
 		LastOffsetIndex: uint32(len(expectedEvents) + 2),
 	}
 
-	lndMock.On("ListForwards", ctx, channelID, startTime, mock.Anything, uint32(0)).Return(resp1, nil).Once()
-	lndMock.On("ListForwards",
-		ctx,
-		channelID,
-		startTime,
-		mock.Anything,
-		uint32(lightning.MaxForwardingEvents),
-	).Return(resp2, nil).Once()
+	lndMock.On("ListForwards", ctx, startTime, mock.Anything, offset).Return(resp1, nil).Once()
+	lndMock.On("ListForwards", ctx, startTime, mock.Anything, uint32(lightning.MaxForwardingEvents)).Return(resp2, nil).Once()
 
-	events, err := ListForwards(ctx, lndMock, channelID, startTime, offset)
+	events, err := ListForwards(ctx, lndMock, startTime)
 	assert.NoError(t, err)
 
 	assert.Equal(t, append(resp1.ForwardingEvents, resp2.ForwardingEvents...), events)

--- a/agent/local/node_test.go
+++ b/agent/local/node_test.go
@@ -61,13 +61,12 @@ func TestGetNode(t *testing.T) {
 			walletResp := &lnrpc.WalletBalanceResponse{
 				ConfirmedBalance: tt.balance,
 			}
-			channelID := uint64(191315023298560)
 			channelsResp := []*lnrpc.Channel{
 				{
 					Active:       true,
 					RemotePubkey: "test_peer",
 					ChannelPoint: "e5b8ccc43b4eea6e2664a843e27d82c6d71d2885e7aef73777dd35c737c1d7bc:1",
-					ChanId:       channelID,
+					ChanId:       191315023298560,
 					Capacity:     2_000_000,
 				},
 			}
@@ -84,7 +83,7 @@ func TestGetNode(t *testing.T) {
 			forwardsResp := &lnrpc.ForwardingHistoryResponse{
 				ForwardingEvents: []*lnrpc.ForwardingEvent{
 					{
-						ChanIdIn:  channelID,
+						ChanIdIn:  191315023298560,
 						AmtInMsat: 500,
 						FeeMsat:   10,
 					},
@@ -99,7 +98,7 @@ func TestGetNode(t *testing.T) {
 			lndMock.On("ListPeers", ctx).Return(peersResp, nil)
 			lndMock.On("ClosedChannels", ctx).Return(closedChannelsResp, nil)
 			lndMock.On("EstimateTxFee", ctx, config.TargetConf).Return(feeResp, nil)
-			lndMock.On("ListForwards", ctx, channelID, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
+			lndMock.On("ListForwards", ctx, mock.Anything, mock.Anything, uint32(0)).Return(forwardsResp, nil)
 
 			expectedNode := local.Node{
 				PublicKey: infoResp.IdentityPubkey,

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -56,7 +56,7 @@ type Client interface {
 	GetChanInfo(ctx context.Context, channelID uint64) (*lnrpc.ChannelEdge, error)
 	GetInfo(ctx context.Context) (*lnrpc.GetInfoResponse, error)
 	ListChannels(ctx context.Context) ([]*lnrpc.Channel, error)
-	ListForwards(ctx context.Context, scid uint64, startTime, endTime uint64, indexOffset uint32) (*lnrpc.ForwardingHistoryResponse, error)
+	ListForwards(ctx context.Context, startTime, endTime uint64, indexOffset uint32) (*lnrpc.ForwardingHistoryResponse, error)
 	ListPeers(ctx context.Context) ([]*lnrpc.Peer, error)
 	QueryRoute(ctx context.Context, publicKey string) (*lnrpc.QueryRoutesResponse, error)
 	UpdateChannelPolicy(ctx context.Context, channelPoint string, baseFeeMsat, feeRatePPM, maxHTLCMsat, timeLockDelta uint64) error
@@ -303,24 +303,16 @@ func (c *client) ListChannels(ctx context.Context) ([]*lnrpc.Channel, error) {
 // ListForwards returns list of successful HTLC forwarding events.
 func (c *client) ListForwards(
 	ctx context.Context,
-	scid uint64,
 	startTime,
 	endTime uint64,
 	indexOffset uint32,
 ) (*lnrpc.ForwardingHistoryResponse, error) {
-	channelIDs := []uint64{scid}
-	if scid == 0 {
-		channelIDs = nil
-	}
-
 	return c.ln.ForwardingHistory(ctx, &lnrpc.ForwardingHistoryRequest{
 		StartTime:       startTime,
 		EndTime:         endTime,
 		IndexOffset:     indexOffset,
 		NumMaxEvents:    MaxForwardingEvents,
 		PeerAliasLookup: false,
-		IncomingChanIds: channelIDs,
-		OutgoingChanIds: channelIDs,
 	})
 }
 

--- a/lightning/mock.go
+++ b/lightning/mock.go
@@ -93,12 +93,11 @@ func (c *ClientMock) ListChannels(ctx context.Context) ([]*lnrpc.Channel, error)
 // ListForwards mock.
 func (c *ClientMock) ListForwards(
 	ctx context.Context,
-	channelID uint64,
 	startTime,
 	endTime uint64,
 	indexOffset uint32,
 ) (*lnrpc.ForwardingHistoryResponse, error) {
-	args := c.Called(ctx, channelID, startTime, endTime, indexOffset)
+	args := c.Called(ctx, startTime, endTime, indexOffset)
 	return mockReturn[*lnrpc.ForwardingHistoryResponse](args)
 }
 


### PR DESCRIPTION
## Description

Simplifies forwards listing by requesting them all at once using pagination instead of filtering+pagination for each channel.